### PR TITLE
use input instead of getpass

### DIFF
--- a/src/pyaerocom_preproc/config.py
+++ b/src/pyaerocom_preproc/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 from functools import lru_cache
-from getpass import getpass
 from pathlib import Path
 
 if sys.version_info >= (3, 11):  # pragma: no cover
@@ -47,8 +46,7 @@ def config(
     """Check S3 credentials file"""
     if not secrets.exists() or overwrite:
         _secrets = {
-            key: getpass(f"{key}: ")
-            for key in ("bucket_name", "access_key_id", "secret_access_key")
+            key: input(f"{key}: ") for key in ("bucket_name", "access_key_id", "secret_access_key")
         }
         secrets.parent.mkdir(True, exist_ok=True)
         secrets.parent.chmod(0o700)  # only user has read/write/execute permissions

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from pyaerocom_preproc.config import _settings, config
 @pytest.fixture
 def secrets(tmp_path: Path, monkeypatch) -> Path:
     path = tmp_path / "secrets.toml"
-    monkeypatch.setattr("pyaerocom_preproc.config.getpass", lambda prompt: prompt.split(":")[0])
+    monkeypatch.setattr("builtins.input", lambda prompt: prompt.split(":")[0])
     return path
 
 
@@ -22,7 +22,7 @@ def secrets_s3_bucket(tmp_path: Path, monkeypatch) -> Path:
             return "s3://s3_bucket_name"
         return prompt.split(":")[0]
 
-    monkeypatch.setattr("pyaerocom_preproc.config.getpass", fake_getpass)
+    monkeypatch.setattr("builtins.input", fake_getpass)
     return path
 
 


### PR DESCRIPTION
[getpass] prompt's the user for a password without echoing. The echo is in fact useful when tying s3 credentials.


[getpass]: https://docs.python.org/3/library/getpass.html#getpass.getpass